### PR TITLE
Add LH2 production to PlanetaryBaseInc ISRU

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksISRU.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksISRU.cfg
@@ -235,3 +235,123 @@
 		 }
 	}
 }
+
+// K&K Planetary ISRU from Nils277's Kerbal Planetary Base Systems
+@PART[KKAOSS_ISRU_g]:NEEDS[PlanetaryBaseInc]:FOR[CryoTanks]
+{
+    MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = LH2
+		StartActionName = Start ISRU [LH2]
+		StopActionName = Stop ISRU [LH2]	 
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500
+			key = 2000 50
+			key = 4000 0
+		}
+		 
+		GeneratesHeat = true
+		ThermalEfficiency
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0
+		}
+		DefaultShutoffTemp = .8
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		Specialty = Engineer
+		EfficiencyBonus = 1
+
+		 
+		 INPUT_RESOURCE
+		 {
+			ResourceName = Ore
+			Ratio = 0.8
+			FlowMode = STAGE_PRIORITY_FLOW
+  		 }
+		 INPUT_RESOURCE
+		 {
+			ResourceName = ElectricCharge
+			Ratio = 40
+		 }
+		 OUTPUT_RESOURCE
+		 {
+			ResourceName = LqdHydrogen
+			Ratio = 112.8
+			DumpExcess = false
+			FlowMode = STAGE_PRIORITY_FLOW
+		 }
+		 
+	}
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = LH2+Ox
+		StartActionName = Start ISRU [LH2+Ox]
+		StopActionName = Stop ISRU [LH2+Ox]	 
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500
+			key = 2000 50
+			key = 4000 0
+		}
+		 
+		GeneratesHeat = true
+		ThermalEfficiency
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0
+		}
+		DefaultShutoffTemp = .8
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		Specialty = Engineer
+		EfficiencyBonus = 1
+
+		 
+		 INPUT_RESOURCE
+		 {
+			ResourceName = Ore
+			Ratio = 0.8
+			FlowMode = STAGE_PRIORITY_FLOW
+  		 }
+		 INPUT_RESOURCE
+		 {
+			ResourceName = ElectricCharge
+			Ratio = 40
+		 }
+		 OUTPUT_RESOURCE
+		 {
+			ResourceName = LqdHydrogen
+			Ratio = 19.79296
+			DumpExcess = false
+			FlowMode = STAGE_PRIORITY_FLOW
+		 }
+		  OUTPUT_RESOURCE
+		 {
+			ResourceName = Oxidizer
+			Ratio = 1.319536
+			DumpExcess = false
+			FlowMode = STAGE_PRIORITY_FLOW
+		 }
+		 
+	}
+}


### PR DESCRIPTION
This adds LH2 production to the planetary ISRU part from [Kerbal Planetary Base Systems](http://forum.kerbalspaceprogram.com/index.php?/topic/133606-12/).

Conversion rate is 80% of stock ISRU, same as for the planetary version's other resource converters.