### PR TITLE
Update CryoTanksFuelTankSwitcher.cfg

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
@@ -1,5 +1,5 @@
 // Lifting tanks
-@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
@@ -86,7 +86,7 @@
 	}
 }
 // ZBO tanks
-@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
 {
 	%LH2 = #$RESOURCE[LqdHydrogen]/maxAmount$
 


### PR DESCRIPTION
Keeps extra B9 tank types from overlaying WBI's tanks regardless of setting.