### PR TITLE
Base volume calc and missed tank type

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
@@ -106,7 +106,7 @@
 		moduleID = fuelSwitch
 		switcherDescription = #LOC_CryoTanks_switcher_fuel_title
 		baseVolume = #$../LH2$
-		@baseVolume *= 0.2
+		@baseVolume /= 7.5
 
 		SUBTYPE
 		{

--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankTypes.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankTypes.cfg
@@ -54,7 +54,7 @@ B9_TANK_TYPE
 	RESOURCE
 	{
 		name = LqdHydrogen
-		unitsPerVolume = 5
+		unitsPerVolume = 7.5
 	}
 }
 B9_TANK_TYPE


### PR DESCRIPTION
The amount of hydrogen defined in the cryo tanks parts config is now 7.5 per unit of volume. Calculate base volume from that.

Updated the second pure hydrogen tank type.