### PR TITLE
Patches: Kerbalism support

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksFuelCells.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelCells.cfg
@@ -6,7 +6,7 @@
 //N.B.: LH2/O->EC requires only 2/3 as much reaction mass per EC as LF/O->EC, but...
 //...powering ZBO tanks with LH2O fuel cells uses 11.88x more LH2 than allowing boil-off
 
-@PART[FuelCell]:FOR[CryoTanks]
+@PART[FuelCell]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]]
   {
@@ -47,7 +47,7 @@
   }
 }
 
-@PART[FuelCellArray]:FOR[CryoTanks]
+@PART[FuelCellArray]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]]
   {
@@ -91,7 +91,7 @@
 //LH2O fuel cells produce Water as an byproduct at a rate of 9/8 * Oxidizer by mass
 //Only if mods that use Water are present
 
-@PART[FuelCell]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport]
+@PART[FuelCell]:AFTER[CryoTanks]:NEEDS[!Kerbalism,KolonyTools|TacLifeSupport]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell??LH2O?]]
   {
@@ -104,7 +104,7 @@
   }
 }
 
-@PART[FuelCellArray]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport]
+@PART[FuelCellArray]:AFTER[CryoTanks]:NEEDS[!Kerbalism,KolonyTools|TacLifeSupport]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell??LH2O?]]
   {

--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
@@ -1,5 +1,5 @@
 // Lifting tanks
-@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch,!modularFuelTanks,!RealFuels]:FOR[zzz_CryoTanks]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
@@ -86,7 +86,7 @@
 	}
 }
 // ZBO tanks
-@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[B9PartSwitch,!modularFuelTanks,!RealFuels]:FOR[zzz_CryoTanks]
 {
 	%LH2 = #$RESOURCE[LqdHydrogen]/maxAmount$
 
@@ -148,5 +148,24 @@
 			BoiloffRate = 0.05
 		}
 
+	}
+}
+
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!B9PartSwitch,!modularFuelTanks,!RealFuels]:FOR[zzz_CryoTanks]
+{
+	!MODULE[ModuleB9PartSwitch],* {}
+
+	MODULE
+	{
+		name =  ModuleCryoTank
+		// in Ec per 1000 units per second
+		CoolingCost = 0.05
+		CoolingEnabled = True
+		BOILOFFCONFIG
+		{
+			FuelName = LqdHydrogen
+			// in % per hr
+			BoiloffRate = 0.05
+		}
 	}
 }

--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankTypes.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankTypes.cfg
@@ -1,5 +1,5 @@
 // Part switcher tank types
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = LH2O
 	tankMass =  0.000278904
@@ -16,7 +16,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 0.333
 	}
 }
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = LH2
 	tankMass =  0.00010627500
@@ -28,7 +28,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 7.5
 	}
 }
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = LH2OCryo
 	tankMass = 0.000278904
@@ -45,7 +45,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 0.333
 	}
 }
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = LH2Cryo
 	tankMass =  0.00010627500
@@ -57,7 +57,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 7.5
 	}
 }
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = OX
 	tankMass = 0.000625
@@ -68,7 +68,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 1
 	}
 }
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = LF
 	tankMass = 0.000625
@@ -79,7 +79,7 @@ B9_TANK_TYPE
 		unitsPerVolume = 1
 	}
 }
-B9_TANK_TYPE
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
 {
 	name = LFOX
 	tankMass = 0.000625

--- a/GameData/CryoTanks/Patches/CryoTanksISRU.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksISRU.cfg
@@ -1,6 +1,6 @@
 // ModuleManager cfg for adding LH 2 and LH2/O extraction to the ISRU
 
-@PART[ISRU]:FOR[CryoTanks]
+@PART[ISRU]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
     MODULE
 	{
@@ -123,7 +123,7 @@
 	}
 }
 
-@PART[MiniISRU]:FOR[CryoTanks]
+@PART[MiniISRU]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
 	MODULE
 	{
@@ -244,7 +244,7 @@
 }
 
 // K&K Planetary ISRU from Nils277's Kerbal Planetary Base Systems
-@PART[KKAOSS_ISRU_g]:NEEDS[PlanetaryBaseInc]:FOR[CryoTanks]
+@PART[KKAOSS_ISRU_g]:NEEDS[!Kerbalism,PlanetaryBaseInc]:FOR[CryoTanks]
 {
     MODULE
 	{


### PR DESCRIPTION
I'm currently repairing Kerbalism support for CryoTanks as it is currently broken 😞
To help support the changes in Kerbalism I have slightly changed the CryoTanks patches.
Changes include the following:
* Removed dependency on B9PartSwitcher, allows basic LH2 tank support if the B9 switcher is not installed.
* Removed the changes to FuelCells and the ISRU as Kerbalism has its own processes for dealing with these parts and LH2 that where created primarily for USI support.