### PR TITLE
Fix Enable/Disable cooling button in Editor

### DIFF
--- a/Source/ModuleSimpleBoiloff.cs
+++ b/Source/ModuleSimpleBoiloff.cs
@@ -36,7 +36,7 @@ namespace SimpleBoiloff
         [KSPField(isPersistant = false)]
         public bool ShortwaveFluxAffectsBoiloff = false;
 
-        // Percent of insolation reflected
+        // Percent of insulation reflected
         [KSPField(isPersistant = false)]
         public float Albedo = 0.5f;
 
@@ -360,7 +360,7 @@ namespace SimpleBoiloff
                 Fields["BoiloffStatus"].guiActive = false;
             }
           }
-          if (HighLogic.LoadedSceneIsEditor)
+          else if (HighLogic.LoadedSceneIsEditor)
           {
               hasResource = false;
               foreach(BoiloffFuel fuel in fuels)
@@ -378,14 +378,10 @@ namespace SimpleBoiloff
                   double max = GetTotalMaxResouceAmount();
 
                   CoolingStatus =  Localizer.Format("#LOC_CryoTanks_ModuleCryoTank_Field_CoolingStatus_Editor", (CoolingCost * (float)(max / 1000.0)).ToString("F2"));
-              }
-              if (CoolingCost > 0f && !hasResource)
-                Fields["CoolingStatus"].guiActive = false;
 
-              if (CoolingCost > 0f)
-              {
                   Events["Disable"].guiActiveEditor = true;
                   Events["Enable"].guiActiveEditor = true;
+
                   if (Events["Enable"].active == CoolingEnabled || Events["Disable"].active != CoolingEnabled)
                   {
                       Events["Disable"].active = CoolingEnabled;
@@ -394,6 +390,7 @@ namespace SimpleBoiloff
               }
               else
               {
+                  Fields["CoolingStatus"].guiActive = false;
                   Events["Disable"].guiActiveEditor = false;
                   Events["Enable"].guiActiveEditor = false;
               }


### PR DESCRIPTION
Enable/Disable button would show in the editor for fuel types not in the BoiloffFuel List.
Button now disappears in these cases.

![screenshot0](https://user-images.githubusercontent.com/17555434/42737576-7f559e2a-886d-11e8-9f37-a28d5095dcaf.png)
