### PR TITLE
Kerbalism compatibility fix

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksCTT.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksCTT.cfg
@@ -3,7 +3,6 @@
 {
 	@TechRequired = specializedFuelStorage
 }
-}
 @PART[hydrogen-5-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
 	@TechRequired = specializedFuelStorage

--- a/GameData/CryoTanks/Patches/CryoTanksFuelCells.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelCells.cfg
@@ -6,7 +6,7 @@
 //N.B.: LH2/O->EC requires only 2/3 as much reaction mass per EC as LF/O->EC, but...
 //...powering ZBO tanks with LH2O fuel cells uses 11.88x more LH2 than allowing boil-off
 
-@PART[FuelCell]:FOR[CryoTanks]
+@PART[FuelCell]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]]
   {
@@ -47,7 +47,7 @@
   }
 }
 
-@PART[FuelCellArray]:FOR[CryoTanks]
+@PART[FuelCellArray]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]]
   {
@@ -91,7 +91,7 @@
 //LH2O fuel cells produce Water as an byproduct at a rate of 9/8 * Oxidizer by mass
 //Only if mods that use Water are present
 
-@PART[FuelCell]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport]
+@PART[FuelCell]:AFTER[CryoTanks]:NEEDS[!Kerbalism,KolonyTools|TacLifeSupport]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell??LH2O?]]
   {
@@ -104,7 +104,7 @@
   }
 }
 
-@PART[FuelCellArray]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport]
+@PART[FuelCellArray]:AFTER[CryoTanks]:NEEDS[!Kerbalism,KolonyTools|TacLifeSupport]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell??LH2O?]]
   {

--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
@@ -1,5 +1,5 @@
 // Lifting tanks
-@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!RealFuels]:FOR[zzz_CryoTanks]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
@@ -86,7 +86,7 @@
 	}
 }
 // ZBO tanks
-@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!modularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!RealFuels]:FOR[zzz_CryoTanks]
 {
 	%LH2 = #$RESOURCE[LqdHydrogen]/maxAmount$
 

--- a/GameData/CryoTanks/Patches/CryoTanksISRU.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksISRU.cfg
@@ -1,6 +1,6 @@
 // ModuleManager cfg for adding LH 2 and LH2/O extraction to the ISRU
 
-@PART[ISRU]:FOR[CryoTanks]
+@PART[ISRU]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
     MODULE
 	{
@@ -123,7 +123,7 @@
 	}
 }
 
-@PART[MiniISRU]:FOR[CryoTanks]
+@PART[MiniISRU]:NEEDS[!Kerbalism]:FOR[CryoTanks]
 {
 	MODULE
 	{
@@ -244,7 +244,7 @@
 }
 
 // K&K Planetary ISRU from Nils277's Kerbal Planetary Base Systems
-@PART[KKAOSS_ISRU_g]:NEEDS[PlanetaryBaseInc]:FOR[CryoTanks]
+@PART[KKAOSS_ISRU_g]:NEEDS[!Kerbalism,PlanetaryBaseInc]:FOR[CryoTanks]
 {
     MODULE
 	{

--- a/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
@@ -1,7 +1,7 @@
 // Procedural Fuel Tanks Patch
 // Svm420
 
-@PART[procedural*Liquid]:NEEDS[ProceduralParts&!ModularFuelTanks&!RealFuels]:FOR[CryoTanks]
+@PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels]:FOR[CryoTanks]
 {
 	@MODULE[TankContentSwitcher]
 	{
@@ -38,4 +38,17 @@
 			}
 		}
 	}
+
+    MODULE
+    {
+        name =  ModuleCryoTank
+        CoolingCost = 0.09
+        CoolingEnabled = False
+        BOILOFFCONFIG
+        {
+            FuelName = LqdHydrogen
+            // in % per hr
+            BoiloffRate = 0.05
+        }
+    } 
 }


### PR DESCRIPTION
+
a bracket too much
+
recreation of

> Modified CryoTanksFuelTankSwitcher.cfg and CryoTanksProceduralFuelTanks.cfg to only block boil off when Real Fuels is used, not when modular fuel tanks is used