### PR TITLE
Optional patch to convert multimode engines to use LH2

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksMultimodeEngines.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksMultimodeEngines.cfg
@@ -1,0 +1,196 @@
+// Create folder "CryoTanksMultimodeEngines" in GameData to enable, this is done to avoid breaking existing ship designs
+// Most recent author: madman2003
+
+// Optional configuring multimode engines (based on SABRE engine concept design by Reaction Engines Limited) to use LH2
+// Cryogenic fluids are used for the precooler (otherwise the engine would melt during air compression)
+// and LH2 in general achieves higher specific momentum (Isp) compared to Kerosine (LiquidFuel)
+// Balance is targetted at stock, which is means Isp is OK, but thrust to weight ratio in real life would be ~50% higher (based on SMURFF observations) for any rocket engine
+// This expresses itself in engines that are too heavy, the mass has been increased to compensate for the very low deltaV requirements of Kerbin
+// But thrust on the low side for Earth level requirements (as opposed to Kerbin)
+
+// Data about TWR at different velocities: https://www.friendsofimperial.org.uk/Media/Slides/201602_SABRE_Engine.pdf
+// And for mass budgets: https://web.archive.org/web/20140127114808/http://www.reactionengines.co.uk/tech_docs/JBIS_v57_22-32.pdf
+// And for thrust budgets: https://web.archive.org/web/20160328220308/http://www.reactionengines.co.uk/tech_docs/SKYLON_Users_Manual_Rev_2.1.pdf
+// This is based on Skylon C1/C2, which is lower performance than Skylon D1, but for the latter less data is available
+
+// Air breathing engines perform comparable in stock as they do in real life
+// TWR target:
+// 7.0 at mach 0.0
+// 14.0 at mach 2.0
+// 5.0 at mach 5.7
+
+// If we take the engine + nacelle masses we arrive at approximately 15000 kg, which is for 2 engines, each delivering 1.8 MN of thrust in rocket mode.
+// We arrive at TWR of 24.5 (rocket engines typically do in the range of 60-80)
+// Needing to scale that down to stock Kerbin levels, the TWR for rocket mode needs to be 16.3
+
+// Figuring out what diameter the real life sabre has is a bit tricky, but it seems about half of the diameter of 6 meter of skylon itself
+// Remember that we start with a 7500 kg engine assembly, and then make it 50% heavier because of Kerbin's silly low deltaV requirements, which is 11.250 kg
+// Scaling that with radius^2:
+// 1.5 meter radius (3.0 meter diameter): 1.0 scale factor --> 11.250 kg mass and thrust of 1.8 MN
+// 1.25 meter radius (2.5 meter diameter): 0.69 scale factor --> 7762 kg mass and thrust of 1.24 MN
+// 0.625 meter radius (1.25 meter diameter): 0.17 scale factor --> 1913 kg mass and thrust of 306 KN
+// The gameparts that we're dealing with are configured between 2000 kg and 7900 kg, which is close enough to leave alone
+
+// Baseline figures summary for 1.25 meter parts
+// ~300 KN thrust rocket, ~275 KN thrust airbreathing@mach 2, ~2000 kg mass, peak Isp air-breathing is 6000@mach 1, peak Isp rocket mode is 460
+// Baseline figures summary for the 2.50 meter parts
+// ~1.25 MN thrust rocket. ~1070 KN thrust airbreating@mach 2, ~7800 kg mass, peak Isp air-breathing is 6000@mach 1, peak Isp rocket mode is 460
+
+@PART[RAPIER,nfa-multimodal-*]:NEEDS[CryoTanks,!RealFuels,CryoTanksMultimodeEngines]:FOR[CryoTanks]
+{
+	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+		}
+
+		@PROPELLANT[IntakeAir]
+		{
+			@ratio /= 20
+		}
+
+		!atmosphereCurve
+		atmosphereCurve
+		{
+			key = 0 6000 // max Isp
+		}
+
+		// mach number + fraction of thrust
+		// compensating for effects of atmCurve to reach desired TWR
+		// mach 0.0 is reached at a pressure of ~1.00 ATM --> keep 0.50
+		// mach 0.8 is reached at a pressure of ~1.00 ATM, but needs to be maintained at ~0.50 ATM as well, go for middle way of ~0.75 ATM --> increase 0.70 by factor 1.2 (atmosphere)
+		// mach 1.0 is reached at a pressure of ~0.85 ATM, but needs to be maintained at ~0.35 ATM as well. go for middle way of ~0.60 ATM --> increase 0.75 by factor 1.4 (atmosphere)
+		// mach 2.0 is reached at a pressure of ~0.30 ATM --> increase 1.00 by factor 3.5 (atmosphere)
+		// mach 3.0 is reached at a pressure of ~0.20 ATM --> increase 0.75 by factor 5.0 (atmosphere)
+		// mach 4.0 is reached at a pressure of ~0.04 ATM --> increase 0.50 by factor 9.8 (atmosphere)
+		// mach 5.7 is reached at a pressure of ~0.04 ATM --> increase 0.36 by a factor 9.8 (atmosphere)
+		// hard cut-off at mach 6.0
+		!velCurve
+		velCurve
+		{
+			key = 0.0 0.50
+			key = 0.8 0.84
+			key = 1.0 1.05
+			key = 2.0 3.50
+			key = 3.0 3.75
+			key = 4.0 4.90
+			key = 5.7 3.53
+			key = 6.0 0.00
+		}
+
+		// mach number + fraction of Isp
+		velCurveIsp
+		{
+			key = 0.0 0.75
+			key = 0.8 0.95
+			key = 1.0 1.00
+			key = 2.0 0.75
+			key = 3.0 0.66
+			key = 4.0 0.60
+			key = 5.7 0.50
+		}
+		useVelCurveIsp = true
+
+		// atmCurve left intact
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 15
+		}
+
+		@PROPELLANT[Oxidizer]
+		{
+			@ratio = 1
+		}
+	}
+}
+
+// slightly worse engine than nfa-multimodal-125-1, except a bit lower mass
+@PART[RAPIER]:NEEDS[CryoTanks,!RealFuels,CryoTanksMultimodeEngines]:FOR[CryoTanks]
+{
+	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
+	{
+		@maxThrust = 265
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
+	{
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 450
+			key = 1 340
+		}
+
+		@maxThrust = 290
+	}
+}
+
+// a little bit more thrust and Isp than rapierEngine
+// more thrust at higher altitudes than rapierEngine (not configured in this patch)
+@PART[nfa-multimodal-125-1]:NEEDS[CryoTanks,!RealFuels,NearFutureAeronautics,CryoTanksMultimodeEngines]:FOR[CryoTanks]
+{
+	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
+	{
+		@maxThrust = 275
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
+	{
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 460
+			key = 1 350
+		}
+
+		@maxThrust = 310
+	}
+}
+
+// more thrust, less rocket Isp compared to nfa-multimodal-25-2
+@PART[nfa-multimodal-25-1]:NEEDS[CryoTanks,!RealFuels,NearFutureAeronautics,CryoTanksMultimodeEngines]:FOR[CryoTanks]
+{
+	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
+	{
+		@maxThrust = 1090
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
+	{
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 440
+			key = 1 330
+		}
+
+		@maxThrust = 1270
+	}
+}
+
+// less thrust, more rocket Isp compared to nfa-multimodal-25-1
+@PART[nfa-multimodal-25-2]:NEEDS[CryoTanks,!RealFuels,NearFutureAeronautics,CryoTanksMultimodeEngines]:FOR[CryoTanks]
+{
+	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
+	{
+		@maxThrust = 1050
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
+	{
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 460
+			key = 1 350
+		}
+
+		@maxThrust = 1230
+	}
+}


### PR DESCRIPTION
I wanted to use multi-mode engines in the form they can actually work, i.e. with LH2.
Your NFA multimode engines + stock rapier make a nice set of engines, they just didn't have a LH2 mode, so I chose to use to work on those.

I'm proposing the patch here, because then it makes sense to include the RAPIER as well.

This patch is optional, because it breaks existing ship designs.

Practically speaking I did a lot of tuning using a test ship using 4 nfa-multimodal-25-2 engines, in combination with RSS+SMURFF. It gets into orbit, but it's not trivial and remaining deltaV is just enough for de-orbiting (as opposed to skylon which is supposed to have 200 m/s for manouvering). Stock is very forgiving on SSTO's, because you take the first 1000-1300 m/s in hybrid mode, and the rest up to 2300 m/s in rocket mode. With earth, you take the same amount in atmosphere and the rest up to 7800 m/s with rocket mode.