### PR TITLE
Reorder and swap descriptions for Inline 5m-144 tank

### DIFF
--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-3.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-3.cfg
@@ -82,22 +82,6 @@ PART
 		}
 		SUBTYPE
 		{
-			name = WhiteCompact
-			transform = COLLIDERCOMPACT
-			transform = COLLIDERTANK1
-			transform = COLLIDERTANK2
-			transform = COLLIDERTANK3
-			transform = COLLIDERTANK4
-			transform = 5mCompactStructExtra
-			transform = 5mStructureCompact
-			transform = 5mCoreStructure
-			transform = Short5mTankIso
-			node = top01
-			node = bottom01
-			title = #LOC_CryoTanks_switcher_tankappearance_variant5
-		}
-		SUBTYPE
-		{
 			name = FoilCompact
 			transform = COLLIDERCOMPACT
 			transform = COLLIDERTANK1
@@ -110,22 +94,23 @@ PART
 			transform = Short5mTankFoil
 			node = top01
 			node = bottom01
-			title = #LOC_CryoTanks_switcher_tankappearance_variant6
+			title = #LOC_CryoTanks_switcher_tankappearance_variant5
 		}
 		SUBTYPE
 		{
-			name = WhiteBare
-			transform = COLLIDERBARE
+			name = WhiteCompact
+			transform = COLLIDERCOMPACT
 			transform = COLLIDERTANK1
 			transform = COLLIDERTANK2
 			transform = COLLIDERTANK3
 			transform = COLLIDERTANK4
-			transform = 5mBare
+			transform = 5mCompactStructExtra
+			transform = 5mStructureCompact
 			transform = 5mCoreStructure
 			transform = Short5mTankIso
-			node = top02
-			node = bottom02
-			title = #LOC_CryoTanks_switcher_tankappearance_variant3
+			node = top01
+			node = bottom01
+			title = #LOC_CryoTanks_switcher_tankappearance_variant6
 		}
 		SUBTYPE
 		{
@@ -138,6 +123,21 @@ PART
 			transform = 5mBare
 			transform = 5mCoreStructure
 			transform = Short5mTankFoil
+			node = top02
+			node = bottom02
+			title = #LOC_CryoTanks_switcher_tankappearance_variant3
+		}
+		SUBTYPE
+		{
+			name = WhiteBare
+			transform = COLLIDERBARE
+			transform = COLLIDERTANK1
+			transform = COLLIDERTANK2
+			transform = COLLIDERTANK3
+			transform = COLLIDERTANK4
+			transform = 5mBare
+			transform = 5mCoreStructure
+			transform = Short5mTankIso
 			node = top02
 			node = bottom02
 			title = #LOC_CryoTanks_switcher_tankappearance_variant4


### PR DESCRIPTION
The subtype descriptions were swapped for the foil and white variants (i.e. #LOC_CryoTanks_switcher_tankappearance_variant5 = Foil [Compact], but is transform = Short5mTankIso in the file). Instead of just changing the title field, the order of the items were changed to match the other parts.