### PR TITLE
Separate switcher for LH2 only and mixed Hydrolox parts

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
@@ -1,24 +1,28 @@
-// Lifting tanks
+// Adds switcher to tanks containing LF and Oxidizer
 @PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!ModularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
 {
+	//Calculate total capacity by units of default resources
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
 
 	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
 	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
-
-
+	
+	//Mass offset is used to ensure correct dry mass of tanks
 	%massOffset = #$totalCap$
 	@massOffset *= 0.000625 // standard dry mass per units of LF/OX
 	@massOffset *= -1
 
+	//Take default resource quantities and multiply by resource units costs to calculate total cost of original resources
 	@LF *= #$@RESOURCE_DEFINITION[LiquidFuel]/unitCost$
 	@OX *= #$@RESOURCE_DEFINITION[Oxidizer]/unitCost$
 
+	//Sum the total costs of both resources and deduct to avoid double counting once resources are added via switcher
 	%costOffset = #$LF$
 	@costOffset += #$OX$
 	@costOffset *= -1
 
+	//remove original resources
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]] {}
@@ -85,19 +89,25 @@
 		}
 	}
 }
-// ZBO tanks
-@PART[*]:HAS[@RESOURCE[LqdHydrogen],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!ModularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
-{
-	%LH2 = #$RESOURCE[LqdHydrogen]/maxAmount$
 
+// Adds switcher to parts by default containing ONLY LqdHydrogen such as CryoTanks ZBO tank parts
+// Assuming all such tanks are Zero Boil off therefore lower cooling cost applies
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!ModularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+{
+	//total capacity by units of default resources, since only one resource, can use directly to calculate tank volume
+	%LH2 = #$RESOURCE[LqdHydrogen]/maxAmount$
+	
+	//Mass offset is used to ensure correct dry mass of tanks
 	%massOffset = #$LH2$
 	@massOffset *= 0.00001417 // <- EDIT HERE (dry mass per unit LH2 capacity)
 	@massOffset *= -1
 
+	// pull unit cost for default resources from CRP resource definition and deducts cost of original resources to avoid double counting of cost
 	%costOffset = #$LH2$
 	@costOffset *= #$@RESOURCE_DEFINITION[LqdHydrogen]/unitCost$
 	@costOffset *= -1
 
+	//remove original resource
 	!RESOURCE[LqdHydrogen] {}
 
 	MODULE
@@ -105,6 +115,8 @@
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = #LOC_CryoTanks_switcher_fuel_title
+
+		//Calculate base volume by pulling total LH2 capacity and divide by LH2 density (7.5 units LH2 per unit volume)
 		baseVolume = #$../LH2$
 		@baseVolume /= 7.5
 
@@ -149,4 +161,91 @@
 		}
 
 	}
+}
+
+//Adds switcher to parts containing BOTH LH2 and Oxidizer by default
+//Same cooling cost as standard LFO tanks
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch],!MODULE[WBIConvertibleStorage],!MODULE[WBIResourceSwitcher]]:NEEDS[!ModularFuelTanks&!RealFuels]:FOR[zzz_CryoTanks]
+{
+	//Calculate total unit capacity
+	%LH2 = #$RESOURCE[LqdHydrogen]/maxAmount$
+	%OX = #$RESOURCE[Oxidizer]/maxAmount$
+
+	%totalCap = #$RESOURCE[LqdHydrogen]/maxAmount$
+	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
+
+	//Mass offset is used to ensure correct dry mass of tanks. Dry mass balanced against reDirect Hydrolox tanks.
+	%massOffset = #$LH2$
+	@massOffset *= 0.000056 // <- EDIT HERE 
+	@massOffset *= -1
+
+	//Take default resource quantities and multiply by resource units costs to calculate total cost of original resources
+	@LH2 *= #$@RESOURCE_DEFINITION[LqdHydrogen]/unitCost$
+	@OX *= #$@RESOURCE_DEFINITION[Oxidizer]/unitCost$
+
+	//Sum the costs of both original resources and deduct to avoid double counting of cost once resources via switcher are added
+	%costOffset = #$LH2$
+	@costOffset += #$OX$
+	@costOffset *= -1
+
+	//Delete original resources
+	!RESOURCE[LqdHydrogen] {}
+	!RESOURCE[Oxidizer] {}
+
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = fuelSwitch
+		switcherDescription = #LOC_CryoTanks_switcher_fuel_title
+
+		//Hydrolox mixed tank is added 4.995 units LH2 per unit tank volume AND 0.333 units Ox per unit volume
+		//Divide total capacity by 5.327 so that LH2 Ox mix tank quantities are nearly identical to original resource values.
+
+		baseVolume = #$../totalCap$
+		@baseVolume /= 5.327
+
+
+		SUBTYPE
+		{
+			name = LH2/O
+			title = #LOC_CryoTanks_switcher_fuel_lh2ox
+			tankType = LH2OCryo
+			addedMass = #$../../massOffset$
+			addedCost = #$../../costOffset$
+		}
+		SUBTYPE
+		{
+			name = LH2
+			title = #LOC_CryoTanks_switcher_fuel_lh2
+			tankType = LH2Cryo
+			addedMass = #$../../massOffset$
+			addedCost = #$../../costOffset$
+		}
+		SUBTYPE
+		{
+			name = Oxidizer
+			title = #LOC_CryoTanks_switcher_fuel_ox
+			tankType = OX
+			addedMass = #$../../massOffset$
+			addedCost = #$../../costOffset$
+		}
+
+	}
+
+	MODULE
+	{
+		name =  ModuleCryoTank
+		// in Ec per 1000 units per second
+		CoolingCost = 0.09
+		CoolingEnabled = True
+		BOILOFFCONFIG
+		{
+			FuelName = LqdHydrogen
+			// in % per hr
+			BoiloffRate = 0.05
+		}
+
+	}
+
 }


### PR DESCRIPTION
This PR should help avoid issues with mods like reDirect that have hydrolox resources in the part CFG and no fuel switcher module.

Changes
- Restrict ZBO patch to parts containing ONLY LH2
- New patch to add fuel switcher to parts containing BOTH LH2 and OX.
- Dry mass for new patch balanced against reDirect Hydrolox tank dry masses.

ps. I took the liberty of adding comments to help understand the calculations being performed in this patch. Took me a while to get my head around it, I think it would help future contributors.