### PR TITLE
Cooling enabled to False for hydrolox tank patch

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelTankSwitcher.cfg
@@ -238,7 +238,7 @@
 		name =  ModuleCryoTank
 		// in Ec per 1000 units per second
 		CoolingCost = 0.09
-		CoolingEnabled = True
+		CoolingEnabled = False
 		BOILOFFCONFIG
 		{
 			FuelName = LqdHydrogen


### PR DESCRIPTION
Accidentally left cooling enabled to true on the patch that targets hydrolox tanks. Setting to false since such tanks are not assumed to be ZBO. 