### PR TITLE
Move each cryo tank to be one tech node above corresponding "plain" tank

### DIFF
--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-10-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-10-1.cfg
@@ -18,7 +18,7 @@ PART
 	node_stack_bottom = 0.0, -5.020251, 0, 0.0, -1.0, 0.0, 5
 	node_attach = -5.042466, 0.0, 0.0, -1.0, 0.0, 0.0,5
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // Highest stock fuel tech node, since this tank is huge
 	entryCost = 125000
 
 	cost = 155250

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-125-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-125-1.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -1.827, 0, 0.0, -1.0, 0.0, 1
 	node_attach = -0.683155, 0.0, 0.0, -1.0, 0.0, 0.0,1
 
-	TechRequired = nuclearPropulsion
+	TechRequired = advFuelSystems  // One step up from the FL-T800
 	entryCost = 4900
 
 	cost = 1078

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-125-2.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-125-2.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -0.892, 0, 0.0, -1.0, 0.0, 1
 	node_attach = -0.683155, 0.0, 0.0, -1.0, 0.0, 0.0,1
 
-	TechRequired = nuclearPropulsion
+	TechRequired = fuelSystems  // One step up from the FL-T400
 	entryCost = 3200
 
 	cost = 539

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-25-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-25-1.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -3.726, 0, 0.0, -1.0, 0.0, 2
 	node_attach = -1.247711, 0.0, 0.0, -1.0, 0.0, 0.0,2
 
-	TechRequired = largeVolumeContainment
+	TechRequired = largeVolumeContainment  // One step up from Rockomax Jumbo-64
 	entryCost = 31000
 
 	cost = 8625

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-25-2.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-25-2.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -1.846, 0, 0.0, -1.0, 0.0, 2
 	node_attach = -1.247711, 0.0, 0.0, -1.0, 0.0, 0.0,2
 
-	TechRequired = largeVolumeContainment
+	TechRequired = advFuelSystems  // One step up from Rockomax X200-32
 	entryCost = 15200
 
 	cost = 4313

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-25-3.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-25-3.cfg
@@ -18,7 +18,7 @@ PART
 	node_stack_bottom01 = 0.0, -0.9335685, 0, 0.0, -1.0, 0.0, 2
 	node_attach = -1.247711, 0.0, 0.0, -1.0, 0.0, 0.0,2
 
-	TechRequired = nuclearPropulsion
+	TechRequired = advFuelSystems  // One step up from Rockomax X200-16
 	entryCost = 10000
 
 	cost = 2156

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-375-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-375-1.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -3.666, 0, 0.0, -1.0, 0.0, 3
 	node_attach = -1.878716, 0.0, 0.0, -1.0, 0.0, 0.0, 3
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // Same as Kerbodyne S3-14400 (can't go any higher in stock)
 	entryCost = 71000
 
 	cost = 19406

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-375-2.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-375-2.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -1.788, 0, 0.0, -1.0, 0.0, 3
 	node_attach = -1.878716, 0.0, 0.0, -1.0, 0.0, 0.0, 3
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // One step up from Kerbodyne S3-7200
 	entryCost = 46500
 
 	cost = 9703

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-375-3.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-375-3.cfg
@@ -19,7 +19,7 @@ PART
 
 	node_attach = -1.878716, 0.0, 0.0, -1.0, 0.0, 0.0, 3
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // One step up from Kerbodyne S3-3600
 	entryCost = 26500
 
 	cost = 4852

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-1.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -7.365, 0, 0.0, -1.0, 0.0, 4
 	node_attach = -2.458, 0.0, 0.0, -1.0, 0.0, 0.0, 4
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // Same as Kerbodyne S4-512 (can't go any higher in stock)
 	entryCost = 105000
 
 	cost = 77625

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-2.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-2.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -3.602, 0, 0.0, -1.0, 0.0, 4
 	node_attach = -2.458, 0.0, 0.0, -1.0, 0.0, 0.0, 4
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // Same as Kerbodyne S4-256 (can't go any higher in stock)
 	entryCost = 84500
 
 	cost = 38813

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-3.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-inline/hydrogen-5-3.cfg
@@ -20,7 +20,7 @@ PART
 	node_stack_bottom02 = 0.0, -1.747, 0, 0.0, -1.0, 0.0, 4
 	node_attach = -2.458, 0.0, 0.0, -1.0, 0.0, 0.0, 4
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // Same as Kerbodyne S4-128 (can't go any higher in stock)
 	entryCost = 84500
 
 	cost = 19406

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-radial/hydrogen-radial-125-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-radial/hydrogen-radial-125-1.cfg
@@ -16,7 +16,7 @@ PART
 
 
 
-	TechRequired = nuclearPropulsion
+	TechRequired = advRocketry  // One step up from FL-T200 (same diameter, similar volume)
 	entryCost = 11000
 
 	node_attach = 0.0, 0.0, 0.682, 0.0, 0.0, -1.0, 1

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-radial/hydrogen-radial-25-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-radial/hydrogen-radial-25-1.cfg
@@ -16,7 +16,7 @@ PART
 
 
 
-	TechRequired = largeVolumeContainment
+	TechRequired = advFuelSystems  // One step up from Rockomax X200-16 (same diameter, similar volume)
 	entryCost = 11000
 
 	node_attach = 1.355, 0.0, 0.0, 1.0, 0.0, 0.0, 2

--- a/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-radial/hydrogen-radial-375-1.cfg
+++ b/GameData/CryoTanks/Parts/HydrogenTanks/hydrogen-radial/hydrogen-radial-375-1.cfg
@@ -16,7 +16,7 @@ PART
 
 
 
-	TechRequired = highPerformanceFuelSystems
+	TechRequired = highPerformanceFuelSystems  // One step up from Kerbodyne S3-7200 (same diameter, similar volume)
 	entryCost = 82000
 
 	node_attach = 0.0, 0.0, 2.163, 0.0, 0.0, -1.0, 3

--- a/GameData/CryoTanks/Patches/CryoTanksCTT.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksCTT.cfg
@@ -37,7 +37,7 @@
 }
 @PART[hydrogen-25-3]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = advFuelSystems  // One step up from Rockomax X200-32
+	@TechRequired = advFuelSystems  // One step up from Rockomax X200-16
 }
 @PART[hydrogen-125-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {

--- a/GameData/CryoTanks/Patches/CryoTanksCTT.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksCTT.cfg
@@ -1,61 +1,61 @@
 // Hydrogen Fuel
 @PART[hydrogen-10-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = specializedFuelStorage
+	@TechRequired = exoticFuelStorage  // Above all the others, because it's huge
 }
 @PART[hydrogen-5-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = specializedFuelStorage
+	@TechRequired = specializedFuelStorage  // One step up from Kerbodyne S4-512
 }
 @PART[hydrogen-5-2]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = highPerformanceFuelSystems
+	@TechRequired = specializedFuelStorage  // One step up from Kerbodyne S4-256
 }
 @PART[hydrogen-5-3]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = highPerformanceFuelSystems
+	@TechRequired = specializedFuelStorage  // One step up from Kerbodyne S4-128
 }
 @PART[hydrogen-375-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = specializedFuelStorage
+	@TechRequired = specializedFuelStorage  // One step up from Kerbodyne S3-14400
 }
 @PART[hydrogen-375-2]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = highPerformanceFuelSystems
+	@TechRequired = highPerformanceFuelSystems  // One step up from Kerbodyne S3-7200
 }
 @PART[hydrogen-375-3]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = highPerformanceFuelSystems
+	@TechRequired = highPerformanceFuelSystems  // One step up from Kerbodyne S3-3600
 }
 @PART[hydrogen-25-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = largeVolumeContainment
+	@TechRequired = largeVolumeContainment  // One step up from Rockomax Jumbo-64
 }
 @PART[hydrogen-25-2]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = nuclearPropulsion
+	@TechRequired = advFuelSystems  // One step up from Rockomax X200-32
 }
 @PART[hydrogen-25-3]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = nuclearPropulsion
+	@TechRequired = advFuelSystems  // One step up from Rockomax X200-32
 }
 @PART[hydrogen-125-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = nuclearPropulsion
+	@TechRequired = advFuelSystems  // One step up from FL-T800
 }
 @PART[hydrogen-125-2]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = nuclearPropulsion
+	@TechRequired = fuelSystems  // One step up from FL-T400
 }
 @PART[hydrogen-radial-125-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = nuclearPropulsion
+	@TechRequired = advRocketry  // One step up from FL-T200 (same diameter, similar volume)
 }
 @PART[hydrogen-radial-25-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = nuclearPropulsion
+	@TechRequired = advFuelSystems  // One step up from Rockomax X200-16 (same diameter, similar volume)
 }
 @PART[hydrogen-radial-375-1]:NEEDS[CommunityTechTree]:FOR[CryoTanks]
 {
-	@TechRequired = largeVolumeContainment
+	@TechRequired = highPerformanceFuelSystems  // One step up from Kerbodyne S3-7200 (same diameter, similar volume)
 }


### PR DESCRIPTION
**This is a rebalancing suggestion, not a bugfix.**

Half the cryo tanks are in the "nuclear propulsion" tech node.  I'm guessing they were put there at a time when nuclear engines were the only things that could use LH2 fuel, but with CryoEngines that's no longer true.  It's awkward that the most basic cryo tanks aren't available until three tech tiers above the early cryo engines.

I've adjusted the tanks' tech nodes so that each cryo tank is one tier above the corresponding non-cryo stock tank.  So, for example, the stock FL-T400 tank is at "Advanced Rocketry", and the Argyle H125-4 (with the same size, shape, and volume) is one step up from there, at "Fuel Systems".  The idea is that each cryo tank is like a regular tank with a bit of extra tech for the insulation.  For the 1.25m, 2.5m, and 3.75m inline sizes, there are exact matches between the cryo and non-cryo tanks to establish this relationship.  For the radial and 5m inline tanks, I used the stock tank with the same diameter and closest-matching volume.  I put the 10m inline tank one tier above everything else, because it's huge (twice the volume of the biggest 5m inline tank).

All the tanks that were in "Nuclear Propulsion" are now in earlier fuel-related nodes that lead up to nuclear, which seems reasonable and shouldn't be too disruptive.  However, several of the bigger tanks have moved to *higher* tech nodes:

* The small and medium 5m tanks moved from "High Performance Fuel Systems" up one step to "Specialized Fuel Storage", because all the stock 5m tanks are in "High Performance" and the cryo ones should be a tier above that.
* The HR-64 spherical 3.75m radial tank moved from "Large Volume Containment" up to "High Performance Fuel Systems", because the most-similar non-cryo tank is the Kerbodyne S3-7200, which is in "Large Volume".
* As mentioned above, the huge 10m spherical inline tank moved from "Specialized Fuel Storage" up to "Exotic Fuel Storage" so that it's a tier above the 5m tanks.  I'm a little uncertain on this because that means it'll cost 1500 more science just to unlock that one part; it might be better to bring it back down with the 5m tanks.  On the other hand, that thing *is* pretty exotic.