### PR TITLE
Update CryoTanksFuelCells.cfg

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksFuelCells.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksFuelCells.cfg
@@ -91,7 +91,7 @@
 //LH2O fuel cells produce Water as an byproduct at a rate of 9/8 * Oxidizer by mass
 //Only if mods that use Water are present
 
-@PART[FuelCell]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport]
+@PART[FuelCell]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport|KerbalHealth]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell??LH2O?]]
   {
@@ -104,7 +104,7 @@
   }
 }
 
-@PART[FuelCellArray]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport]
+@PART[FuelCellArray]:AFTER[CryoTanks]:NEEDS[KolonyTools|TacLifeSupport|KerbalHealth]
 {
   @MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell??LH2O?]]
   {


### PR DESCRIPTION
LH2O fuel cells produce Water if KerbalHealth is present. KH uses Water as radiation shielding.