### PR TITLE
ModularFuelTanks Compatibility Fixes

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksModularFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksModularFuelTanks.cfg
@@ -1,90 +1,46 @@
 // CryoEngine MFT (Modular Fuel Tanks) Configuration File
 // by funk 09/22/2015
-//------------------------------------------------------//
-
-// Adds LqdHydrogen to Default tank definition
-@TANK_DEFINITION[Default]:NEEDS[ModularFuelTanks&!RealFuels]:FOR[CryoTanks]
-{
-    TANK
-    {
-        name = LqdHydrogen
-        amount = 0
-        maxAmount = 0
-        utilization = 10
-		mass = -0.0003386364
-    }
-}
-
-// Adds LqdHydrogen to Fuselage tank definition
-@TANK_DEFINITION[Fuselage]:NEEDS[ModularFuelTanks&!RealFuels]:FOR[CryoTanks]
-{
-    TANK
-    {
-        name = LqdHydrogen
-        amount = 0
-        maxAmount = 0
-        utilization = 10
-		mass = -0.0003386364
-    }
-}
-
-// Adds LqdHydrogen to Structural tank definition
-@TANK_DEFINITION[Structural]:NEEDS[ModularFuelTanks&!RealFuels]:FOR[CryoTanks]
-{
-    TANK
-    {
-        name = LqdHydrogen
-        amount = 0
-        maxAmount = 0
-        mass = -0.0000261364
-        utilization = 10
-    }
-}
-
-// Adds LqdHydrogen to ServiceModule tank definition
-@TANK_DEFINITION[ServiceModule]:NEEDS[ModularFuelTanks&!RealFuels]:FOR[CryoTanks]
-{
-    TANK
-    {
-        name = LqdHydrogen
-        amount = 0
-        maxAmount = 0
-        utilization = 10
-		mass = -0.0003386364
-    }
-}
 
 //------------------------------------------------------//
 // Adds tank definition for CryoEngines
 TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
 {
     name = Cryogenic
-    basemass = 0.000625 * volume						// if basemass is already described in part cfg. through other MFT patches, MFT won't update to basemass defined in tank definitions. Applies to most spaceplane parts.
+    basemass = 0.0000016 * volume						// if basemass is already described in part cfg. through other MFT patches, MFT won't update to basemass defined in tank definitions. Applies to most spaceplane parts.
     baseCost = 0.2 * volume								// weird behaviour: -x * volume -> costs = default drycosts incl. recources; x = 0.2 -> drycosts = default drycosts * ~122%
     TANK
     {
         name = LqdHydrogen
-        amount = full
-        maxAmount = 60%
-        utilization = 10
-		mass = -0.0003386364
+        amount = 0.0
+        maxAmount = 0.0
+        utilization = 1
+		mass = 0.0000016
     }
     TANK
     {
         name = Oxidizer
-        amount = full
-        maxAmount = 40%
+        amount = 0.0
+        maxAmount = 0.0
     }
 	 TANK
     {
         name = Monopropellant
-        amount = 0
-        maxAmount = 5%
+        amount = 0.0
+        maxAmount = 0.0
     }
+	TANK
+	{
+		name = LqdMethane
+		mass = 0.0000096
+		amount = 0.0
+		maxAmount = 0.0
+		utilization = 1
+		
+	}
 }
 
 //------------------------------------------------------//
-// Adds tank type Cryogenic to all default and fuselage tanks
+// Adds tank type Cryogenic to all default and fuselage tanks, and boiloff/cooling to all MFT tanks
 @PART[*]:HAS[@MODULE[ModuleFuelTanks]]:NEEDS[!RealFuels]:FOR[zzz_CryoTanks]
 {
 	@MODULE[ModuleFuelTanks]:HAS[#type[Default]]
@@ -98,6 +54,16 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
        	%typeAvailable = Fuselage
        	typeAvailable = Cryogenic
    	}
+	@MODULE[ModuleFuelTanks]:HAS[#type[Structural]]
+  	{
+       	%typeAvailable = Structural
+       	typeAvailable = Cryogenic
+   	}
+	@MODULE[ModuleFuelTanks]:HAS[#type[B9_Fuselage]]
+  	{
+       	%typeAvailable = B9_Fuselage
+       	typeAvailable = Cryogenic
+   	}
 	MODULE
 	{
 		name =  ModuleCryoTank
@@ -109,7 +75,26 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
 			FuelName = LqdHydrogen
 			// in % per hr
 			BoiloffRate = 0.05
+			CoolingCost = 0.09
 		}
-
+    BOILOFFCONFIG
+		{
+			FuelName = LqdMethane
+			// in % per hr
+			BoiloffRate = 0.005
+			CoolingCost = 0.045
+		}
 	}
+}
+//Adds tank type Croygenic to B9 MFT tanks
+@TANK_DEFINITION[B9_Fuselage]:NEEDS[B9_Aerospace&ModularFuelTanks&!RealFuels]:FOR[CryoTanks]:FINAL
+{
+    TANK
+    {
+        name = LqdHydrogen
+        amount = 0
+        maxAmount = 0
+        utilization = 1
+		mass = 0.0000016
+    }
 }

--- a/GameData/CryoTanks/Patches/CryoTanksModularFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksModularFuelTanks.cfg
@@ -13,8 +13,8 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
         name = LqdHydrogen
         amount = 0.0
         maxAmount = 0.0
-        utilization = 1
-		mass = 0.0000016
+        utilization = 10
+		
     }
     TANK
     {
@@ -28,13 +28,19 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
         amount = 0.0
         maxAmount = 0.0
     }
+	 TANK
+    {
+        name = LiquidFuel
+        amount = 0.0
+        maxAmount = 0.0
+    }
 	TANK
 	{
 		name = LqdMethane
-		mass = 0.0000096
+		mass = 0.0000080
 		amount = 0.0
 		maxAmount = 0.0
-		utilization = 1
+		utilization = 10
 		
 	}
 }
@@ -86,15 +92,4 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
 		}
 	}
 }
-//Adds tank type Croygenic to B9 MFT tanks
-@TANK_DEFINITION[B9_Fuselage]:NEEDS[B9_Aerospace&ModularFuelTanks&!RealFuels]:FOR[CryoTanks]:FINAL
-{
-    TANK
-    {
-        name = LqdHydrogen
-        amount = 0
-        maxAmount = 0
-        utilization = 1
-		mass = 0.0000016
-    }
-}
+

--- a/GameData/CryoTanks/Patches/CryoTanksModularFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksModularFuelTanks.cfg
@@ -13,7 +13,7 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
         name = LqdHydrogen
         amount = 0.0
         maxAmount = 0.0
-        utilization = 10
+        utilization = 7.5
 		
     }
     TANK
@@ -40,7 +40,7 @@ TANK_DEFINITION:NEEDS[ModularFuelTanks&!RealFuels]
 		mass = 0.0000080
 		amount = 0.0
 		maxAmount = 0.0
-		utilization = 10
+		utilization = 5
 		
 	}
 }


### PR DESCRIPTION
Adds boiloff to MFT tanks, only allows LH2 and CH2 in Cryogenic tanks and changes the tank masses to comport with RF weights instead of the negative mass trick previously used. Fixed typo in previous PR.